### PR TITLE
[SGP-24225] Add tuple support to `requests_timeout` parameter

### DIFF
--- a/marketorestpython/client.py
+++ b/marketorestpython/client.py
@@ -30,7 +30,19 @@ class MarketoClient:
         self.API_CALLS_MADE = 0
         self.API_LIMIT = api_limit
         if requests_timeout is not None:
-            assert isinstance(requests_timeout, int), "requests_timeout must be an integer"
+            error_message = "requests_timeout must be a postive float or int, or a two-element tuple of positive floats or ints"
+            if isinstance(requests_timeout, int) or isinstance(requests_timeout, float):
+                assert requests_timeout > 0, error_message
+                self.requests_timeout = requests_timeout
+            elif isinstance(requests_timeout, tuple):
+                assert (
+                        len(requests_timeout) == 2 and
+                        all(isinstance(x, int) or isinstance(x, float) for x in requests_timeout) and
+                        all(x > 0 for x in requests_timeout)
+                ), error_message
+                self.requests_timeout = requests_timeout
+            else:
+                raise AssertionError(error_message)
         self.requests_timeout = requests_timeout
 
     def _api_call(self, method, endpoint, *args, **kwargs):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,8 +24,13 @@ def test_marketo_client(client):
     assert client.API_LIMIT == 20
     assert client.requests_timeout == 10
 
-    with pytest.raises(AssertionError):
-        MarketoClient('123-FDY-456', 'randomclientid', 'supersecret', 20, requests_timeout="not an int")
+    client = MarketoClient('123-FDY-456', 'randomclientid', 'supersecret', requests_timeout=(1,2.0))
+    assert client.requests_timeout == (1,2.0)
+
+    invalid_requests_timeouts = ["a string", -1, (1,2,3), (1, -1), (1,"a string"), (1,)]
+    for invalid_requests_timeout in invalid_requests_timeouts:
+        with pytest.raises(AssertionError):
+            MarketoClient('123-FDY-456', 'randomclientid', 'supersecret', 20, requests_timeout=invalid_requests_timeout)
 
 
 @patch('marketorestpython.client.HttpLib')


### PR DESCRIPTION
This PR adds support for passing a two-tuple of ints/floats to the `requests` calls in `MarketoClient`. This form is for specifying a separate connect and read timeout value to `requests`.